### PR TITLE
Fixed bug in add on zsh <= 4.3.10

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -68,10 +68,19 @@ wd_add()
     local force=$1
     local point=$2
 
-    if [[ "$point" =~ "^\.+$" || "$point" =~ "^\s*$" ]]
+    if [[ $point =~ "^[\.]+$" ]]
     then
-        wd_print_msg $RED "Illegal warp point (see README)."
-    elif [[ ${points[$point]} == "" ]] || $force
+        wd_print_msg $RED "Warp point cannot be just dots"
+    elif [[ $point =~ "(\s|\ )+" ]]
+    then
+        wd_print_msg $RED "Warp point should not contain whitespace"
+    elif [[ $point == *:* ]]
+    then
+        wd_print_msg $RED "Warp point cannot contain colons"
+    elif [[ $point == "" ]]
+    then
+        wd_print_msg $RED "Warp point cannot be empty"
+    elif [[ ${points[$2]} == "" ]] || $force
     then
         wd_remove $point > /dev/null
         printf "%q:%q\n" "${point}" "${PWD}" >> $CONFIG


### PR DESCRIPTION
See http://www.zsh.org/mla/workers/2014/msg00501.html for details.
At time of writing, some RedHat and CentOS still have 4.3.10 as
the most up-to-date zsh in their package managers, so this should
allow wd to work on those systems properly.
