### PR TITLE
OS X fixes

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -97,7 +97,7 @@ wd_remove()
 
     if [[ ${points[$point]} != "" ]]
     then
-        if sed -i.bak "s,^${point}f:.*$,,g" $CONFIG
+        if sed -i.bak "s,^${point}:.*$,,g" $CONFIG
         then
             wd_print_msg $GREEN "Warp point removed"
         else


### PR DESCRIPTION
The test command ('[') does not have '-a' as one of its options under OS X (BSD) for file testing; its the logical 'and' operator between tests. I'm inferring you just want a simple existence test; thus '-e' should work.

Additionally, there appears to be an extra 'f' character in the sed command. In my quick testing, the adding and removing of warp points displays the correct messages but the rm command does not actually remove the warp point from the file. Deleting the 'f' character from the sed command results in the warp point being removed from the file.
