### PR TITLE
Typo fix and clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Run either in terminal:
  * Add `wd` function to `.zshrc` (or `.profile` etc.):
 
         wd() {
-            . ~/paht/to/wd/wd.sh
+            . ~/path/to/cloned/repo/wd/wd.sh
         }
 
  * Install manpage. From `wd`'s base directory (requires root permissions):


### PR DESCRIPTION
When manually installing after automatic install it might be a bit unclear that the path should be repointed to the manually installed one.
