### PR TITLE
Ensure aligned arrows in list command

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -203,6 +203,21 @@ wd_list_all()
 {
     wd_print_msg $WD_BLUE "All warp points:"
 
+    local entries=$(sed "s:${HOME}:~:g" $WD_CONFIG)
+
+    local max_warp_point_length=0
+    while IFS= read -r line
+    do
+        local arr=(${(s,:,)line})
+        local key=${arr[1]}
+
+        local length=${#key}
+        if [[ length -gt max_warp_point_length ]]
+        then
+            max_warp_point_length=$length
+        fi
+    done <<< $entries
+
     while IFS= read -r line
     do
         if [[ $line != "" ]]
@@ -213,10 +228,10 @@ wd_list_all()
 
             if [[ -z $wd_quiet_mode ]]
             then
-                printf "%20s  ->  %s\n" $key $val
+                printf "%${max_warp_point_length}s  ->  %s\n" $key $val
             fi
         fi
-    done <<< $(sed "s:${HOME}:~:g" $WD_CONFIG)
+    done <<< $entries
 }
 
 wd_ls()

--- a/wd.sh
+++ b/wd.sh
@@ -203,15 +203,15 @@ wd_list_all()
 {
     wd_print_msg $WD_BLUE "All warp points:"
 
-    local entries=$(sed "s:${HOME}:~:g" $WD_CONFIG)
+    entries=$(sed "s:${HOME}:~:g" $WD_CONFIG)
 
-    local max_warp_point_length=0
+    max_warp_point_length=0
     while IFS= read -r line
     do
-        local arr=(${(s,:,)line})
-        local key=${arr[1]}
+        arr=(${(s,:,)line})
+        key=${arr[1]}
 
-        local length=${#key}
+        length=${#key}
         if [[ length -gt max_warp_point_length ]]
         then
             max_warp_point_length=$length


### PR DESCRIPTION
Before listing out each key and value when running `wd list`, it will figure out the length of the longest key string and use that when formatting instead of always printing 20 characters. That will make sure that the arrows are aligned properly, even if the keys are longer than 20 characters long, and it will also use less than 20 characters if no key is that long.

The solution is a little bit dirty in that it will loop through the entries in `$WD_CONFIG` twice. Another solution could be to store the max in the config file for reference, and update this in `wd add` (or `add!`), but I figured this solution was safer and wouldn't break anything else in the process.

Also, I would love to write a test for this, but unfortunately I'm not too familiar with _shunit2_. I did, however, read through the existing `list` tests, and figured it would need to be something like this:
```zsh
wd -q add some-very-very-long-warp-directory-key

expected=" * All warp points:
                                   foo  ->  ${PWD/#$HOME/~}
                                   bar  ->  ${PWD/#$HOME/~}
some-very-very-long-warp-directory-key  ->  ${PWD/#$HOME/~}"
actual=$(wd list)
assertEquals "should align the arrows properly" \
    "$expected" "$actual"
```

The problem with this (I think) is the blue star in the header:
```
 test git:(fix/align-arrows) ✗ ./tests.sh
test_empty_config
test_simple_add_remove
test_no_duplicates
test_valid_identifiers
test_removal
test_list
ASSERT:should align the arrows properly expected:< * All warp points:
                                   foo  ->  ~/code/personal/wd/test
                                   bar  ->  ~/code/personal/wd/test
some-very-very-long-warp-directory-key  ->  ~/code/personal/wd/test> but was:< * All warp points:
                                   foo  ->  ~/code/personal/wd/test
                                   bar  ->  ~/code/personal/wd/test
some-very-very-long-warp-directory-key  ->  ~/code/personal/wd/test>
test_show
test_quiet
test_clean
test_ls
test_path

Ran 11 tests.

FAILED (failures=1)
```
(It doesn't show in the output here, but the header obviously has a blue asterisk, which I think is the reason it doesn't match). I'm also not very confident with putting the header in there, but my limited shunit2 knowledge doesn't include partially matching strings, unfortunately. You might have some input here. :smile: 

