### PR TITLE
fix wd clean to avoid mistaken delete

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -228,7 +228,7 @@ test_quiet()
 
 test_clean()
 {
-    dir=test_dir
+    dir="$HOME/.wdunittest"
 
     # create test dir
     mkdir $dir
@@ -251,15 +251,19 @@ test_clean()
         fail "should remove one warp point when answering yes"
     fi
 
-    # recreate the test dir
-    dir=test_dir
-
-    # create test dir
+    # recreate test dir
     mkdir $dir
     cd $dir
 
     # add warp point
     wd -q add test
+
+    if [[ ! $(echo "y" | wd clean) =~ "No warp points to clean, carry on!" ]]
+    then
+        fail "there should be no invalid warp point"
+    fi
+
+	wd -q add! test
 
     # remove test dir
     cd ..

--- a/wd.sh
+++ b/wd.sh
@@ -294,7 +294,7 @@ wd_clean() {
             key=${arr[1]}
             val=${arr[2]}
 
-            if [ -d "$val" ]
+            if [ -d "${val/#\~/$HOME}" ]
             then
                 wd_tmp=$wd_tmp"\n"`echo $line`
             else


### PR DESCRIPTION
Since `[ -d "$var" ]` can't recognise the `~` in `$var`, when do `wd clean`, directories which contain '~' will be deleted incorrectly.
