### PR TITLE
Add note about installing through the AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Run either in terminal:
 
  * `wget --no-check-certificate https://github.com/mfaerevaag/wd/raw/master/install.sh -O - | sh`
 
+##### Arch ([AUR](https://aur.archlinux.org/))
+
+    # yaourt -S zsh-plugin-wd-git
+
 
 #### Manual
 


### PR DESCRIPTION
Hi,

I took the liberty of putting your original plugin version of `wd` [on the AUR] for easy access for us Arch people. Now, you may or may not be interested in this (seeing as you already have the [C port] in the AUR), but I thought I'd just suggest it nevertheless. For those that still want the Zsh plugin version of `wd` and aren't using oh-my-zsh, I think this could be nice to have.

[on the AUR]: https://aur.archlinux.org/packages/zsh-plugin-wd-git/

[C port]: https://github.com/mfaerevaag/wd-c/

Also, if you'd like to maintain the AUR package together with your C port package on the AUR, please feel free to say so, I'm more than happy to transfer it over to you.

Thanks for making our lives easier through `wd`! :smile: 