### PR TITLE
warp directly to subdir of warp point

### DIFF
--- a/_wd.sh
+++ b/_wd.sh
@@ -16,6 +16,16 @@ function _wd() {
 
   warp_points=( "${(f)mapfile[$CONFIG]//$HOME/~}" )
 
+  typeset -A points
+  while read -r line
+  do
+    arr=(${(s,:,)line})
+    key=${arr[1]}
+    val=${arr[2]}
+
+    points[$key]=$val
+  done < $CONFIG
+
   commands=(
     'add:Adds the current working directory to your warp points'
     'add!:Overwrites existing warp point'
@@ -34,13 +44,15 @@ function _wd() {
     '1: :->first_arg' \
     '2: :->second_arg' && ret=0
 
+  local target=$words[2]
+
   case $state in
     first_arg)
       _describe -t warp_points "Warp points" warp_points && ret=0
       _describe -t commands "Commands" commands && ret=0
       ;;
     second_arg)
-      case $words[2] in
+      case $target in
         add\!|rm)
           _describe -t points "Warp points" warp_points && ret=0
           ;;
@@ -55,6 +67,10 @@ function _wd() {
           ;;
         path)
           _describe -t points "Warp points" warp_points && ret=0
+          ;;
+        *)
+          # complete sub directories from the warp point
+          _path_files -W "(${points[$target]})" -/ && ret=0
           ;;
       esac
       ;;

--- a/wd.sh
+++ b/wd.sh
@@ -131,6 +131,7 @@ wd_getdir()
 wd_warp()
 {
     local point=$1
+    local sub=$2
 
     if [[ $point =~ "^\.+$" ]]
     then
@@ -143,7 +144,12 @@ wd_warp()
         fi
     elif [[ ${points[$point]} != "" ]]
     then
-        cd ${points[$point]/#\~/$HOME}
+        if [[ $sub != "" ]]
+        then
+            cd ${points[$point]/#\~/$HOME}/$sub
+        else
+            cd ${points[$point]/#\~/$HOME}
+        fi
     else
         wd_exit_fail "Unknown warp point '${point}'"
     fi
@@ -424,7 +430,7 @@ else
                 break
                 ;;
             *)
-                wd_warp $o
+                wd_warp $o $2
                 break
                 ;;
             --)


### PR DESCRIPTION
With this we have path completion after warp point, so typing

wd foo <tab>

will list all subfolders of the foo wp's target dir. Only folders are
shown. It's a smooth completion because typing <tab> twice after the
warp points name gives the completion.