### PR TITLE
Eliminate wordsplitting when getting basename

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -165,7 +165,7 @@ wd_add()
 
     if [[ $point == "" ]]
     then
-        point=$(basename $(pwd))
+        point=$(basename $PWD)
     fi
 
     if [[ $point =~ "^[\.]+$" ]]
@@ -198,7 +198,7 @@ wd_remove()
 
     if [[ $point == "" ]]
     then
-        point=$(basename $(pwd))
+        point=$(basename $PWD)
     fi
 
     if [[ ${points[$point]} != "" ]]


### PR DESCRIPTION
Fixes #47. Sort of. You still can't add a warp point with spaces, but at least you get the right error message now.