### PR TITLE
Add support for customizable warp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ Also, you may have to force a rebuild of `zcompdump` by running:
         $ wd --quiet <action>
 
 
+### Configuration
+
+You can configure `wd` with the following environment variables:
+
+#### `WD_CONFIG`
+
+Defines the path where warp points get stored. Defaults to `$HOME/.warprc`.
+
+
 ### Testing
 
 `wd` comes with a small test suite, run with [shunit2](https://code.google.com/p/shunit2/). This can be used to confirm that things are working as it should on your setup, or to demonstrate an issue.

--- a/_wd.sh
+++ b/_wd.sh
@@ -8,13 +8,13 @@ zstyle ':completion::complete:wd::' list-grouped
 zmodload zsh/mapfile
 
 function _wd() {
-  local CONFIG=$HOME/.warprc
+  local WD_CONFIG=${WD_CONFIG:-$HOME/.warprc}
   local ret=1
 
   local -a commands
   local -a warp_points
 
-  warp_points=( "${(f)mapfile[$CONFIG]//$HOME/~}" )
+  warp_points=( "${(f)mapfile[$WD_CONFIG]//$HOME/~}" )
 
   typeset -A points
   while read -r line
@@ -27,7 +27,7 @@ function _wd() {
     target_path=${target_path/#\~/$HOME}
 
     points[$name]=$target_path
-  done < $CONFIG
+  done < $WD_CONFIG
 
   commands=(
     'add:Adds the current working directory to your warp points'

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -8,7 +8,7 @@
 ### Variables
 
 # use a test config file, which is removed at the final test teardown.
-export WD_CONFIG=$(mktemp)
+export WD_CONFIG="$(mktemp)"
 
 # used when testing
 WD_TEST_DIR=test_dir
@@ -40,8 +40,8 @@ WD_PATH=${PWD}/..
 
 wd()
 {
-    # run the local wd with the test config
-    ${WD_PATH}/wd.sh -d -c $WD_CONFIG "$@"
+    # run the local wd in debug mode
+    ${WD_PATH}/wd.sh -d "$@"
 }
 
 total_wps()
@@ -361,6 +361,19 @@ test_path()
 
     # clean up
     destroy_test_wp
+}
+
+test_config()
+{
+    local arg_config="$(mktemp)"
+    local wd_config_lines=$(total_wps)
+
+    wd -q --config $arg_config add
+
+    assertEquals 1 $(wc -l < $arg_config)
+    assertEquals $wd_config_lines $(total_wps)
+
+    rm $arg_config
 }
 
 

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -8,7 +8,7 @@
 ### Variables
 
 # use a test config file, which is removed at the final test teardown.
-WD_TEST_CONFIG=~/.warprc_test
+export WD_CONFIG=$(mktemp)
 
 # used when testing
 WD_TEST_DIR=test_dir
@@ -25,13 +25,13 @@ SHUNIT_PARENT=$0
 # reset config for each test
 setUp()
 {
-    cat /dev/null > $WD_TEST_CONFIG
+    cat /dev/null > $WD_CONFIG
 }
 
 oneTimeTearDown()
 {
     rm -rf $WD_TEST_DIR $WD_TEST_DIR_2
-    rm $WD_TEST_CONFIG
+    rm $WD_CONFIG
 }
 
 ### Helpers
@@ -41,13 +41,13 @@ WD_PATH=${PWD}/..
 wd()
 {
     # run the local wd with the test config
-    ${WD_PATH}/wd.sh -d -c $WD_TEST_CONFIG "$@"
+    ${WD_PATH}/wd.sh -d -c $WD_CONFIG "$@"
 }
 
 total_wps()
 {
     # total wps is the number of (non-empty) lines in the config
-    echo $(cat $WD_TEST_CONFIG | sed '/^\s*$/d' | wc -l)
+    echo $(cat $WD_CONFIG | sed '/^\s*$/d' | wc -l)
 }
 
 wp_exists()

--- a/wd.sh
+++ b/wd.sh
@@ -334,7 +334,7 @@ wd_clean() {
     fi
 }
 
-local WD_CONFIG=$HOME/.warprc
+local WD_CONFIG=${WD_CONFIG:-$HOME/.warprc}
 local WD_QUIET=0
 local WD_EXIT_CODE=0
 local WD_DEBUG=0


### PR DESCRIPTION
With this PR
* `WD_CONFIG` will no longer be overwritten, and can be set by the user, to specify a custom location for the warp file
* the completion uses `WD_CONFIG` to determine the warp file

Issue #52 