### PR TITLE
Add quotes around case labels

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -36,11 +36,11 @@ wd_yesorno()
         read -r answer
 
         case ${answer:=${default}} in
-            Y|y|YES|yes|Yes )
+            "Y"|"y"|"YES"|"yes"|"Yes" )
                 RETVAL=${yes_RETVAL} && \
                     break
                 ;;
-            N|n|NO|no|No )
+            "N"|"n"|"NO"|"no"|"No" )
                 RETVAL=${no_RETVAL} && \
                     break
                 ;;
@@ -400,43 +400,43 @@ else
     do
         case "$o"
             in
-            -a|--add|add)
+            "-a"|"--add"|"add")
                 wd_add false $2
                 break
                 ;;
-            -a!|--add!|add!)
+            "-a!"|"--add!"|"add!")
                 wd_add true $2
                 break
                 ;;
-            -r|--remove|rm)
+            "-r"|"--remove"|"rm")
                 wd_remove $2
                 break
                 ;;
-            -l|list)
+            "-l"|"list")
                 wd_list_all
                 break
                 ;;
-            -ls|ls)
+            "-ls"|"ls")
                 wd_ls $2
                 break
                 ;;
-            -p|--path|path)
+            "-p"|"--path"|"path")
                 wd_path $2
                 break
                 ;;
-            -h|--help|help)
+            "-h"|"--help"|"help")
                 wd_print_usage
                 break
                 ;;
-            -s|--show|show)
+            "-s"|"--show"|"show")
                 wd_show $2
                 break
                 ;;
-            -c|--clean|clean)
+            "-c"|"--clean"|"clean")
                 wd_clean false
                 break
                 ;;
-            -c!|--clean!|clean!)
+            "-c!"|"--clean!"|"clean!")
                 wd_clean true
                 break
                 ;;


### PR DESCRIPTION
zsh supports global aliases, which are expanded "anywhere", including
case labels, potentially causing unwanted behaviors or parsing errors.

I have a "NO" (No Output) alias which is "NO: globally aliased to > /dev/null 2>&1".
Because the wd.sh script is sourced from an interactive shell, this alias was present
and was causing a parsing error.
