### PR TITLE
Save fixes - Preserve symlinks and improved tmpfile generation

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -204,7 +204,8 @@ wd_remove()
     if [[ ${points[$point]} != "" ]]
     then
         local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
-        if sed -n "/^${point}:.*$/!p" $WD_CONFIG > $config_tmp && mv $config_tmp $WD_CONFIG
+        # Copy and delete in two steps in order to preserve symlinks
+        if sed -n "/^${point}:.*$/!p" $WD_CONFIG > $config_tmp && cp $config_tmp $WD_CONFIG && rm $config_tmp
         then
             wd_print_msg $WD_GREEN "Warp point removed"
         else

--- a/wd.sh
+++ b/wd.sh
@@ -203,7 +203,7 @@ wd_remove()
 
     if [[ ${points[$point]} != "" ]]
     then
-        local config_tmp=$WD_CONFIG.tmp
+        local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
         if sed -n "/^${point}:.*$/!p" $WD_CONFIG > $config_tmp && mv $config_tmp $WD_CONFIG
         then
             wd_print_msg $WD_GREEN "Warp point removed"


### PR DESCRIPTION
* Copy and delete in two steps in order to preserve symlinks
* Use mktemp to generate temporary file location

