### PR TITLE
added static named directories export

### DIFF
--- a/_wd.sh
+++ b/_wd.sh
@@ -32,6 +32,7 @@ function _wd() {
   commands=(
     'add:Adds the current working directory to your warp points'
     'add!:Overwrites existing warp point'
+    'export:Export warp points as static named directories'
     'rm:Removes the given warp point'
     'list:Outputs all stored warp points'
     'ls:Show files from given warp point'

--- a/wd.sh
+++ b/wd.sh
@@ -422,7 +422,7 @@ else
                 wd_add true $2
                 break
                 ;;
-            -e|export)
+            "-e"|"export")
                 wd_export_static_named_directories
                 break
                 ;;

--- a/wd.sh
+++ b/wd.sh
@@ -182,6 +182,8 @@ wd_add()
         wd_remove $point > /dev/null
         printf "%q:%s\n" "${point}" "${PWD/#$HOME/~}" >> $WD_CONFIG
 
+        wd_export_static_named_directories
+
         wd_print_msg $WD_GREEN "Warp point added"
 
         # override exit code in case wd_remove did not remove any points
@@ -335,6 +337,15 @@ wd_clean() {
     fi
 }
 
+wd_export_static_named_directories() {
+  if [[ -z $WD_SKIP_EXPORT ]]
+  then
+    for warpdir ($(grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/')) {
+      hash -d $warpdir
+    }
+  fi
+}
+
 local WD_CONFIG=${WD_CONFIG:-$HOME/.warprc}
 local WD_QUIET=0
 local WD_EXIT_CODE=0
@@ -365,6 +376,8 @@ if [ ! -e $WD_CONFIG ]
 then
     # if not, create config file
     touch $WD_CONFIG
+else
+    wd_export_static_named_directories
 fi
 
 # load warp points
@@ -407,6 +420,10 @@ else
                 ;;
             "-a!"|"--add!"|"add!")
                 wd_add true $2
+                break
+                ;;
+            -e|export)
+                wd_export_static_named_directories
                 break
                 ;;
             "-r"|"--remove"|"rm")
@@ -467,6 +484,7 @@ unset wd_print_usage
 unset wd_alt_config
 unset wd_quiet_mode
 unset wd_print_version
+unset wd_export_static_named_directories
 
 unset args
 unset points


### PR DESCRIPTION
I've integrated the export as additional command into `wd.sh`.

- `wd export` needs to be called from `.zshrc` (or the oh-my-zsh plugin file)
- seems this needs to be called with `.` (source) for the hash function to work (`. wd export`)
- entries are added unless `WD_SKIP_EXPORT` is set
- new entries are exported (`wd add`)
- removed entries are currently ignored until next shell is opened (it is possible to empty the hash table with `hash -d -r` and regenerate but that might affect other custom entries)
- i haven't added that yet because i'm not sure if that might affect some users (removes all custom entries - shouldn't be a problem though)

I'm not too sure about this solution since sourcing the `wd.sh` file in `.zshrc` gives a little delay (though not much) so i'm open for ideas. Simply adding the grep/hash loop to the `wd.plugin.zsh`/`.zshrc` still seems to be the easiest way.

resolves #60 