### PR TITLE
Iterate CLI args with a local, prefixed variable

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -410,9 +410,10 @@ then
 else
 
     # parse rest of options
-    for o
+    local wd_o;
+    for wd_o
     do
-        case "$o"
+        case "$wd_o"
             in
             "-a"|"--add"|"add")
                 wd_add false $2
@@ -485,6 +486,7 @@ unset wd_alt_config
 unset wd_quiet_mode
 unset wd_print_version
 unset wd_export_static_named_directories
+unset wd_o
 
 unset args
 unset points

--- a/wd.sh
+++ b/wd.sh
@@ -410,7 +410,7 @@ then
 else
 
     # parse rest of options
-    local wd_o;
+    local wd_o
     for wd_o
     do
         case "$wd_o"
@@ -460,7 +460,7 @@ else
                 break
                 ;;
             *)
-                wd_warp $o $2
+                wd_warp $wd_o $2
                 break
                 ;;
             --)


### PR DESCRIPTION
Fixes #65 

The name `o`, chosen initially, could be used as an alias by some user, which would break the plugin. Making the variable local and prefixed makes sure that the name is going to be somewhat unique :)