### PR TITLE
prevent subdir autocompletion for non-existent warp points

### DIFF
--- a/_wd.sh
+++ b/_wd.sh
@@ -73,8 +73,12 @@ function _wd() {
           _describe -t points "Warp points" warp_points && ret=0
           ;;
         *)
-          # complete sub directories from the warp point
-          _path_files -W "(${points[$target]})" -/ && ret=0
+          if [[ -v points[$target] ]]; then
+            # complete sub directories from the warp point
+            _path_files -W "(${points[$target]})" -/ && ret=0
+          fi
+          
+          # don't complete anything if warp point is not valid
           ;;
       esac
       ;;


### PR DESCRIPTION
fixes #67 

new behaviour is that tab doesn't show any prompts or lists if the warp point is not found, which seems intuitive to me, but might not be as friendly as I think it is