### PR TITLE
Fix wd_export_static_named_directories() throwing warnings

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -342,9 +342,9 @@ wd_clean() {
 wd_export_static_named_directories() {
   if [[ -z $WD_SKIP_EXPORT ]]
   then
-    for warpdir ($(grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/')) {
-      hash -d $warpdir
-    }
+    grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/' | while read warpdir ; do
+	    hash -d "$warpdir"
+    done
   fi
 }
 


### PR DESCRIPTION
If a warp directory had whitespace in the path (e.g. `/home/atk/Git Projects/wd`), then the `hash` function on line 346 would throw a warning that it wasn't being given a valid directory (the warp still worked). This was because the for loop splits on any whitespace, so having a space in a path name would bugger everything and the single warp point would be split at every whitespace. To fix this, I changed the loop to use a `read`, which splits on newlines only, thus allowing everything to work as intended.

Running the tests for me failed epicly, though from lightly using my modified version I'm honestly not sure why. Test output:
```test_empty_config
test_simple_add_remove
ASSERT:should successfully add wp 'foo'
ASSERT:should have 1 wps expected:<1> but was:<0>
ASSERT:wp 'foo' should exist
test_default_add_remove
ASSERT:should successfully add wp to PWD
ASSERT:should have 1 wps expected:<1> but was:<0>
ASSERT:wp to PWD should exist
test_no_duplicates
ASSERT:should successfully add 'foo'
test_default_no_duplicates
ASSERT:should successfully add warp point to PWD
ASSERT:should successfully force-add warp point to PWD
test_default_multiple_directories
ASSERT:should successfully add warp point to PWD
ASSERT:should successfully add warp point to another PWD
test_valid_identifiers
ASSERT:should allow dots in name
test_removal
ASSERT:should remove existing point
test_list
ASSERT:should only be one warp point expected:<0> but was:<2>
ASSERT:should be more than one warp point expected:<0> but was:<3>
test_show
ASSERT:should show no warp points
ASSERT:should show 1 warp point 'foo'
ASSERT:should show 2 warp points 'foo bar'
ASSERT:should show warp point 'foo'
ASSERT:should not show warp point 'qux'
test_quiet
test_clean
ASSERT:should be able to abort cleanup
ASSERT:should remove one warp point when answering yes
ASSERT:there should be no invalid warp point
ASSERT:should remove one warp point when using force
test_ls
ASSERT:should list correct files
test_path
ASSERT:should give correct path
test_config
ASSERT:expected:<1> but was:<0>

Ran 15 tests.

FAILED (failures=27)```