### PR TITLE
Alphabetize warp points when they are added

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -183,6 +183,11 @@ wd_add()
     then
         wd_remove $point > /dev/null
         printf "%q:%s\n" "${point}" "${PWD/#$HOME/~}" >> $WD_CONFIG
+        if (whence sort >/dev/null); then
+            local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
+            # use 'cat' below to ensure we respect $WD_CONFIG as a symlink
+            sort -o "${config_tmp}" $WD_CONFIG  && cat "${config_tmp}" > $WD_CONFIG && rm "${config_tmp}"
+        fi
 
         wd_export_static_named_directories
 


### PR DESCRIPTION
When using `wd list` or `wd <TAB>`, which shows the list of warp points, I find it incredibly helpful to have the warp points alphabetized.

Because I believe what is convenient for me is right for everyone else, I did not implement a toggle for whether to enable this sort or not. 😉 I'm happy to implement that if you think it makes sense.