### PR TITLE
Multi remove

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -430,7 +430,10 @@ else
                 break
                 ;;
             "-r"|"--remove"|"rm")
-                wd_remove $2
+                # Loop over all arguments after "rm", separated by whitespace
+                for pointname in "${@:2}" ; do
+                    wd_remove $pointname
+                done
                 break
                 ;;
             "-l"|"list")


### PR DESCRIPTION
Will close #16, allows removal of multiple warp points in one go

No tests for this yet, may work out how to write those in due course.

Only one of the commits coming through is relevant for the change - 7fb1383. The other is simply as a result of me updating my fork, so you should be able to rebase my patch onto your master without needing both commits.

Here's a patch file if you'd prefer

```
---
 wd.sh | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

diff --git a/wd.sh b/wd.sh
index 802ed10..f073897 100755
--- a/wd.sh
+++ b/wd.sh
@@ -430,7 +430,10 @@ else
                 break
                 ;;
             "-r"|"--remove"|"rm")
-                wd_remove $2
+                # Loop over all arguments after "rm", separated by whitespace
+                for pointname in "${@:2}" ; do
+                    wd_remove $pointname
+                done
                 break
                 ;;
             "-l"|"list")
--
2.27.0
```