### PR TITLE
Change WD_SKIP_EXPORT to WD_EXPORT

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -345,7 +345,7 @@ wd_clean() {
 }
 
 wd_export_static_named_directories() {
-  if [[ -z $WD_SKIP_EXPORT ]]
+  if [[ ! -z $WD_EXPORT ]]
   then
     command grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/' | while read warpdir ; do
         hash -d "$warpdir"


### PR DESCRIPTION
This effectively makes exporting static named directories off by default, stopping `wd` from messing with path names in terminal prompts

Closes #85 