### PR TITLE
Use file tools with full path to avoid capture by alias

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -214,7 +214,7 @@ wd_remove()
     then
         local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
         # Copy and delete in two steps in order to preserve symlinks
-        if sed -n "/^${point}:.*$/!p" $WD_CONFIG > $config_tmp && cp $config_tmp $WD_CONFIG && rm $config_tmp
+        if sed -n "/^${point}:.*$/!p" $WD_CONFIG > $config_tmp && /bin/cp $config_tmp $WD_CONFIG && /bin/rm $config_tmp
         then
             wd_print_msg $WD_GREEN "Warp point removed"
         else


### PR DESCRIPTION
The short commands `cp` and `rm` are often aliased to `cp -i` and `rm -i` to
avoid accidental overwrites and deletes, but this breaks the behavior of wd.