### PR TITLE
Increase compliance with `shellcheck` best practices

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -25,13 +25,13 @@ SHUNIT_PARENT=$0
 # reset config for each test
 setUp()
 {
-    cat /dev/null > $WD_CONFIG
+    cat /dev/null > "$WD_CONFIG"
 }
 
 oneTimeTearDown()
 {
-    rm -rf $WD_TEST_DIR $WD_TEST_DIR_2
-    rm $WD_CONFIG
+    rm -rf "$WD_TEST_DIR" "$WD_TEST_DIR_2"
+    rm "$WD_CONFIG"
 }
 
 ### Helpers
@@ -41,13 +41,13 @@ WD_PATH=${PWD}/..
 wd()
 {
     # run the local wd in debug mode
-    ${WD_PATH}/wd.sh -d "$@"
+    "${WD_PATH}"/wd.sh -d "$@"
 }
 
 total_wps()
 {
     # total wps is the number of (non-empty) lines in the config
-    echo $(cat $WD_CONFIG | sed '/^\s*$/d' | wc -l)
+    echo "$(sed '/^\s*$/d' "$WD_CONFIG" | wc -l)"
 }
 
 wp_exists()
@@ -59,18 +59,18 @@ wp_exists()
 create_test_wp()
 {
     # create test dir
-    mkdir $WD_TEST_DIR
+    mkdir "$WD_TEST_DIR"
 
     # create test wp
-    cd $WD_TEST_DIR
-    wd -q add $WD_TEST_WP
+    cd "$WD_TEST_DIR"
+    wd -q add "$WD_TEST_WP"
     cd ..
 }
 
 destroy_test_wp()
 {
-    rm -rf $WD_TEST_DIR
-    wd -q rm $WD_TEST_DIR
+    rm -rf "$WD_TEST_DIR"
+    wd -q rm "$WD_TEST_DIR"
 }
 
 
@@ -80,119 +80,119 @@ destroy_test_wp()
 test_empty_config()
 {
     assertEquals "should initially be an empty config" \
-        0 $(total_wps)
+        0 "$(total_wps)"
 }
 
 test_simple_add_remove()
 {
     wd -q add foo
     assertTrue "should successfully add wp 'foo'" \
-        $pipestatus
+        "$pipestatus"
 
     assertEquals "should have 1 wps" \
-        1 $(total_wps)
+        1 "$(total_wps)"
 
     assertTrue "wp 'foo' should exist" \
-        $(wp_exists "foo")
+        "$(wp_exists "foo")"
 
     wd -q rm foo
     assertEquals "wps should be empty" \
-        0 $(total_wps)
+        0 "$(total_wps)"
 }
 
 test_default_add_remove()
 {
-    cwd=$(basename $PWD)
+    cwd=$(basename "$PWD")
 
     wd -q add
     assertTrue "should successfully add wp to PWD" \
-               $pipestatus
+               "$pipestatus"
 
     assertEquals "should have 1 wps" \
-                 1 $(total_wps)
+                 1 "$(total_wps)"
 
     assertTrue "wp to PWD should exist" \
-               $(wp_exists $cwd)
+               "$(wp_exists "$cwd")"
 
     wd -q rm
     assertEquals "wps should be empty" \
-                 0 $(total_wps)
+                 0 "$(total_wps)"
 }
 
 test_no_duplicates()
 {
     wd -q add foo
     assertTrue "should successfully add 'foo'" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add foo
     assertFalse "should fail when adding duplicate of 'foo'" \
-        $pipestatus
+        "$pipestatus"
 }
 
 test_default_no_duplicates()
 {
-    cwd=$(basename $PWD)
+    cwd=$(basename "$PWD")
 
     wd -q add
     assertTrue "should successfully add warp point to PWD" \
-               $pipestatus
+               "$pipestatus"
 
     wd -q add
     assertFalse "should fail when adding duplicate of PWD" \
-                $pipestatus
+                "$pipestatus"
 
     wd -q add!
     assertTrue "should successfully force-add warp point to PWD" \
-               $pipestatus
+               "$pipestatus"
 }
 
 test_default_multiple_directories()
 {
-    rm -rf $WD_TEST_DIR
-    mkdir $WD_TEST_DIR
-    cd $WD_TEST_DIR
+    rm -rf "$WD_TEST_DIR"
+    mkdir "$WD_TEST_DIR"
+    cd "$WD_TEST_DIR"
     wd -q add
     assertTrue "should successfully add warp point to PWD" \
-               $pipestatus
+               "$pipestatus"
     cd ..
-    rmdir $WD_TEST_DIR
+    rmdir "$WD_TEST_DIR"
 
-    rm -rf $WD_TEST_DIR_2
-    mkdir $WD_TEST_DIR_2
-    cd $WD_TEST_DIR_2
+    rm -rf "$WD_TEST_DIR_2"
+    mkdir "$WD_TEST_DIR_2"
+    cd "$WD_TEST_DIR_2"
     wd -q add
     assertTrue "should successfully add warp point to another PWD" \
-               $pipestatus
+               "$pipestatus"
     cd ..
-    rmdir $WD_TEST_DIR_2
+    rmdir "$WD_TEST_DIR_2"
 }
 
 test_valid_identifiers()
 {
     wd -q add .
     assertFalse "should not allow only dots" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add ..
     assertFalse "should not allow only dots" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add hej.
     assertTrue "should allow dots in name" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add "foo bar"
     assertFalse "should not allow whitespace" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add "foo:bar"
     assertFalse "should not allow colons" \
-        $pipestatus
+        "$pipestatus"
 
     wd -q add ":foo"
     assertFalse "should not allow colons" \
-        $pipestatus
+        "$pipestatus"
 }
 
 test_removal()
@@ -201,11 +201,11 @@ test_removal()
 
     wd -q rm bar
     assertFalse "should fail when removing non-existing point" \
-                $pipestatus
+                "$pipestatus"
 
     wd -q rm foo
     assertTrue "should remove existing point" \
-               $pipestatus
+               "$pipestatus"
 }
 
 test_list()
@@ -214,17 +214,17 @@ test_list()
 
     # add one to expected number of lines, because of header msg
     assertEquals "should only be one warp point" \
-        $(wd list | wc -l) 2
+        "$(wd list | wc -l)" 2
 
     wd -q add bar
 
     assertEquals "should be more than one warp point" \
-        $(wd list | wc -l) 3
+        "$(wd list | wc -l)" 3
 }
 
 test_show()
 {
-    if [[ ! $(wd show) =~ "No warp point to $(echo $PWD | sed "s:$HOME:~:")" ]]
+    if [[ ! $(wd show) =~ "No warp point to $(echo "$PWD" | sed "s:$HOME:~:")" ]]
     then
         fail "should show no warp points"
     fi
@@ -283,15 +283,15 @@ test_clean()
     dir="$HOME/.wdunittest"
 
     # create test dir
-    mkdir $dir
-    cd $dir
+    mkdir "$dir"
+    cd "$dir"
 
     # add warp point
     wd -q add test
 
     # remove test dir
     cd ..
-    rmdir $dir
+    rmdir "$dir"
 
     if [[ ! $(echo "n" | wd clean) =~ "Cleanup aborted" ]]
     then
@@ -304,8 +304,8 @@ test_clean()
     fi
 
     # recreate test dir
-    mkdir $dir
-    cd $dir
+    mkdir "$dir"
+    cd "$dir"
 
     # add warp point
     wd -q add test
@@ -319,7 +319,7 @@ test_clean()
 
     # remove test dir
     cd ..
-    rmdir $dir
+    rmdir "$dir"
 
     if [[ ! $(wd clean!) =~ ".*1 warp point\(s\) removed" ]]
     then
@@ -333,8 +333,8 @@ test_ls()
     create_test_wp
 
     # create test files in dir
-    touch $WD_TEST_DIR/foo
-    touch $WD_TEST_DIR/bar
+    touch "$WD_TEST_DIR/foo"
+    touch "$WD_TEST_DIR/bar"
 
     # assert correct output
     if [[ ! $(wd ls $WD_TEST_WP) =~ "bar.*foo" ]]
@@ -351,10 +351,10 @@ test_path()
     # set up
     create_test_wp
 
-    local pwd=$(echo $PWD | sed "s:${HOME}:~:g")
+    local pwd=$(echo "$PWD" | sed "s:${HOME}:~:g")
 
     # assert correct output
-    if [[ ! $(wd path $WD_TEST_WP) =~ "${pwd}/${WD_TEST_DIR}" ]]
+    if [[ ! $(wd path "$WD_TEST_WP") =~ "${pwd}/${WD_TEST_DIR}" ]]
     then
         fail "should give correct path"
     fi
@@ -368,12 +368,12 @@ test_config()
     local arg_config="$(mktemp)"
     local wd_config_lines=$(total_wps)
 
-    wd -q --config $arg_config add
+    wd -q --config "$arg_config" add
 
-    assertEquals 1 $(wc -l < $arg_config)
-    assertEquals $wd_config_lines $(total_wps)
+    assertEquals 1 "$(wc -l < "$arg_config")"
+    assertEquals "$wd_config_lines" "$(total_wps)"
 
-    rm $arg_config
+    rm "$arg_config"
 }
 
 

--- a/wd.sh
+++ b/wd.sh
@@ -103,7 +103,7 @@ wd_exit_fail()
 {
     local msg=$1
 
-    wd_print_msg $WD_RED $msg
+    wd_print_msg "$WD_RED" "$msg"
     WD_EXIT_CODE=1
 }
 
@@ -111,7 +111,7 @@ wd_exit_warn()
 {
     local msg=$1
 
-    wd_print_msg $WD_YELLOW $msg
+    wd_print_msg "$WD_YELLOW" "$msg"
     WD_EXIT_CODE=1
 }
 
@@ -119,7 +119,7 @@ wd_getdir()
 {
     local name_arg=$1
 
-    point=$(wd_show $name_arg)
+    point=$(wd_show "$name_arg")
     dir=${point:28+$#name_arg+7}
 
     if [[ -z $name_arg ]]; then
@@ -167,7 +167,7 @@ wd_add()
 
     if [[ $point == "" ]]
     then
-        point=$(basename $PWD)
+        point=$(basename "$PWD")
     fi
 
     if [[ $point =~ "^[\.]+$" ]]
@@ -181,17 +181,17 @@ wd_add()
         wd_exit_fail "Warp point cannot contain colons"
     elif [[ ${points[$point]} == "" ]] || $force
     then
-        wd_remove $point > /dev/null
-        printf "%q:%s\n" "${point}" "${PWD/#$HOME/~}" >> $WD_CONFIG
+        wd_remove "$point" > /dev/null
+        printf "%q:%s\n" "${point}" "${PWD/#$HOME/~}" >> "$WD_CONFIG"
         if (whence sort >/dev/null); then
             local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
             # use 'cat' below to ensure we respect $WD_CONFIG as a symlink
-            sort -o "${config_tmp}" $WD_CONFIG  && cat "${config_tmp}" > $WD_CONFIG && rm "${config_tmp}"
+            sort -o "${config_tmp}" "$WD_CONFIG"  && cat "${config_tmp}" > "$WD_CONFIG" && rm "${config_tmp}"
         fi
 
         wd_export_static_named_directories
 
-        wd_print_msg $WD_GREEN "Warp point added"
+        wd_print_msg "$WD_GREEN" "Warp point added"
 
         # override exit code in case wd_remove did not remove any points
         # TODO: we should handle this kind of logic better
@@ -205,9 +205,9 @@ wd_remove()
 {
     local point_list=$1
 
-    if [[ $point_list == "" ]]
+    if [[ "$point_list" == "" ]]
     then
-        point_list=$(basename $PWD)
+        point_list=$(basename "$PWD")
     fi
 
     for point_name in $point_list ; do
@@ -215,9 +215,9 @@ wd_remove()
         then
             local config_tmp=$(mktemp "${TMPDIR:-/tmp}/wd.XXXXXXXXXX")
             # Copy and delete in two steps in order to preserve symlinks
-            if sed -n "/^${point_name}:.*$/!p" $WD_CONFIG > $config_tmp && command cp $config_tmp $WD_CONFIG && command rm $config_tmp
+            if sed -n "/^${point_name}:.*$/!p" "$WD_CONFIG" > "$config_tmp" && command cp "$config_tmp" "$WD_CONFIG" && command rm "$config_tmp"
             then
-                wd_print_msg $WD_GREEN "Warp point removed"
+                wd_print_msg "$WD_GREEN" "Warp point removed"
             else
                 wd_exit_fail "Something bad happened! Sorry."
             fi
@@ -229,9 +229,9 @@ wd_remove()
 
 wd_list_all()
 {
-    wd_print_msg $WD_BLUE "All warp points:"
+    wd_print_msg "$WD_BLUE" "All warp points:"
 
-    entries=$(sed "s:${HOME}:~:g" $WD_CONFIG)
+    entries=$(sed "s:${HOME}:~:g" "$WD_CONFIG")
 
     max_warp_point_length=0
     while IFS= read -r line
@@ -244,7 +244,7 @@ wd_list_all()
         then
             max_warp_point_length=$length
         fi
-    done <<< $entries
+    done <<< "$entries"
 
     while IFS= read -r line
     do
@@ -256,35 +256,35 @@ wd_list_all()
 
             if [[ -z $wd_quiet_mode ]]
             then
-                printf "%${max_warp_point_length}s  ->  %s\n" $key $val
+                printf "%${max_warp_point_length}s  ->  %s\n" "$key" "$val"
             fi
         fi
-    done <<< $entries
+    done <<< "$entries"
 }
 
 wd_ls()
 {
-    wd_getdir $1
-    ls ${dir/#\~/$HOME}
+    wd_getdir "$1"
+    ls "${dir/#\~/$HOME}"
 }
 
 wd_path()
 {
-    wd_getdir $1
-    echo $(echo $dir | sed "s:${HOME}:~:g")
+    wd_getdir "$1"
+    echo "$(echo "$dir" | sed "s:${HOME}:~:g")"
 }
 
 wd_show()
 {
     local name_arg=$1
     # if there's an argument we look up the value
-    if [[ ! -z $name_arg ]]
+    if [[ -n $name_arg ]]
     then
         if [[ -z $points[$name_arg] ]]
         then
-            wd_print_msg $WD_BLUE "No warp point named $name_arg"
+            wd_print_msg "$WD_BLUE" "No warp point named $name_arg"
         else
-            wd_print_msg $WD_GREEN "Warp point: ${WD_GREEN}$name_arg${WD_NOC} -> $points[$name_arg]"
+            wd_print_msg "$WD_GREEN" "Warp point: ${WD_GREEN}$name_arg${WD_NOC} -> $points[$name_arg]"
         fi
     else
         # hax to create a local empty array
@@ -292,19 +292,19 @@ wd_show()
         wd_matches=()
         # do a reverse lookup to check whether PWD is in $points
         PWD="${PWD/$HOME/~}"
-        if [[ ${points[(r)$PWD]} == $PWD ]]
+        if [[ ${points[(r)$PWD]} == "$PWD" ]]
         then
             for name in ${(k)points}
             do
-                if [[ $points[$name] == $PWD ]]
+                if [[ $points[$name] == "$PWD" ]]
                 then
                     wd_matches[$(($#wd_matches+1))]=$name
                 fi
             done
 
-            wd_print_msg $WD_BLUE "$#wd_matches warp point(s) to current directory: ${WD_GREEN}$wd_matches${WD_NOC}"
+            wd_print_msg "$WD_BLUE" "$#wd_matches warp point(s) to current directory: ${WD_GREEN}$wd_matches${WD_NOC}"
         else
-            wd_print_msg $WD_YELLOW "No warp point to $(echo $PWD | sed "s:$HOME:~:")"
+            wd_print_msg "$WD_YELLOW" "No warp point to $(echo "$PWD" | sed "s:$HOME:~:")"
         fi
     fi
 }
@@ -314,7 +314,7 @@ wd_clean() {
     local count=0
     local wd_tmp=""
 
-    while read line
+    while read -r line
     do
         if [[ $line != "" ]]
         then
@@ -324,24 +324,24 @@ wd_clean() {
 
             if [ -d "${val/#\~/$HOME}" ]
             then
-                wd_tmp=$wd_tmp"\n"`echo $line`
+                wd_tmp=$wd_tmp"\n"`echo "$line"`
             else
-                wd_print_msg $WD_YELLOW "Nonexistent directory: ${key} -> ${val}"
+                wd_print_msg "$WD_YELLOW" "Nonexistent directory: ${key} -> ${val}"
                 count=$((count+1))
             fi
         fi
-    done < $WD_CONFIG
+    done < "$WD_CONFIG"
 
     if [[ $count -eq 0 ]]
     then
-        wd_print_msg $WD_BLUE "No warp points to clean, carry on!"
+        wd_print_msg" $WD_BLUE" "No warp points to clean, carry on!"
     else
         if $force || wd_yesorno "Removing ${count} warp points. Continue? (Y/n)"
         then
-            echo $wd_tmp >! $WD_CONFIG
-            wd_print_msg $WD_GREEN "Cleanup complete. ${count} warp point(s) removed"
+            echo "$wd_tmp" >! "$WD_CONFIG"
+            wd_print_msg "$WD_GREEN" "Cleanup complete. ${count} warp point(s) removed"
         else
-            wd_print_msg $WD_BLUE "Cleanup aborted"
+            wd_print_msg "$WD_BLUE" "Cleanup aborted"
         fi
     fi
 }
@@ -349,7 +349,7 @@ wd_clean() {
 wd_export_static_named_directories() {
   if [[ ! -z $WD_EXPORT ]]
   then
-    command grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/' | while read warpdir ; do
+    command grep '^[0-9a-zA-Z_-]\+:' "$WD_CONFIG" | sed -e "s,~,$HOME," -e 's/:/=/' | while read -r warpdir ; do
         hash -d "$warpdir"
     done
   fi
@@ -381,10 +381,10 @@ then
 fi
 
 # check if config file exists
-if [ ! -e $WD_CONFIG ]
+if [ ! -e "$WD_CONFIG" ]
 then
     # if not, create config file
-    touch $WD_CONFIG
+    touch "$WD_CONFIG"
 else
     wd_export_static_named_directories
 fi
@@ -399,7 +399,7 @@ do
     val=${(j,:,)arr[2,-1]}
 
     points[$key]=$val
-done < $WD_CONFIG
+done < "$WD_CONFIG"
 
 # get opts
 args=$(getopt -o a:r:c:lhs -l add:,rm:,clean\!,list,ls:,path:,help,show -- $*)
@@ -409,8 +409,8 @@ if [[ ($? -ne 0 || $#* -eq 0) && -z $wd_print_version ]]
 then
     wd_print_usage
 
-    # check if config file is writeable
-elif [ ! -w $WD_CONFIG ]
+# check if config file is writeable
+elif [ ! -w "$WD_CONFIG" ]
 then
     # do nothing
     # can't run `exit`, as this would exit the executing shell
@@ -425,11 +425,11 @@ else
         case "$wd_o"
             in
             "-a"|"--add"|"add")
-                wd_add false $2
+                wd_add false "$2"
                 break
                 ;;
             "-a!"|"--add!"|"add!")
-                wd_add true $2
+                wd_add true "$2"
                 break
                 ;;
             "-e"|"export")
@@ -437,8 +437,15 @@ else
                 break
                 ;;
             "-r"|"--remove"|"rm")
+<<<<<<< HEAD
                 # Passes all the arguments as a single string separated by whitespace to wd_remove
                 wd_remove "${@:2}"
+=======
+                # Loop over all arguments after "rm", separated by whitespace
+                for pointname in "${@:2}" ; do
+                    wd_remove "$pointname"
+                done
+>>>>>>> 297fa81... Add a lot of "quotation" marks
                 break
                 ;;
             "-l"|"list")
@@ -446,11 +453,11 @@ else
                 break
                 ;;
             "-ls"|"ls")
-                wd_ls $2
+                wd_ls "$2"
                 break
                 ;;
             "-p"|"--path"|"path")
-                wd_path $2
+                wd_path "$2"
                 break
                 ;;
             "-h"|"--help"|"help")
@@ -458,7 +465,7 @@ else
                 break
                 ;;
             "-s"|"--show"|"show")
-                wd_show $2
+                wd_show "$2"
                 break
                 ;;
             "-c"|"--clean"|"clean")
@@ -470,7 +477,7 @@ else
                 break
                 ;;
             *)
-                wd_warp $wd_o $2
+                wd_warp "$wd_o" "$2"
                 break
                 ;;
             --)
@@ -502,7 +509,7 @@ unset args
 unset points
 unset val &> /dev/null # fixes issue #1
 
-if [[ ! -z $wd_debug_mode ]]
+if [[ -n $wd_debug_mode ]]
 then
     exit $WD_EXIT_CODE
 else


### PR DESCRIPTION
Essentially I used the [`shellcheck`](https://www.shellcheck.net/) tool to pick over `wd` and try and improve the code style, particularly robustness against whitespace. This PR therefore will solve #89.

It is worth noting `shellcheck` does not natively support zsh so I ran it in bash mode and simply didn't touch anything too technical in syntax which could have been zsh specific. Most of the changes therefore are just adding loads of "quotations" all over the place.