### PR TITLE
Change `wd path` to give absolute path

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -351,7 +351,7 @@ test_path()
     # set up
     create_test_wp
 
-    local pwd=$(echo "$PWD" | sed "s:${HOME}:~:g")
+    local pwd=$(echo "$PWD" | sed "s:~:${HOME}:g")
 
     # assert correct output
     if [[ ! $(wd path "$WD_TEST_WP") =~ "${pwd}/${WD_TEST_DIR}" ]]

--- a/wd.sh
+++ b/wd.sh
@@ -270,7 +270,7 @@ wd_ls()
 wd_path()
 {
     wd_getdir "$1"
-    echo "$(echo "$dir" | sed "s:${HOME}:~:g")"
+    echo "$(echo "$dir" | sed "s:~:${HOME}:g")"
 }
 
 wd_show()


### PR DESCRIPTION
Will close #91 

Updated test logic to do the same

Maybe it'd be better to control if an absolute path is given or not through a flag, instead of just changing the default behaviour. Thoughts?