### PR TITLE
Prevent usage of slashes in warp points

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -351,7 +351,7 @@ test_path()
     # set up
     create_test_wp
 
-    local pwd=$(echo "$PWD" | sed "s:${HOME}:~:g")
+    local pwd=$(echo "$PWD" | sed "s:~:${HOME}:g")
 
     # assert correct output
     if [[ ! $(wd path "$WD_TEST_WP") =~ "${pwd}/${WD_TEST_DIR}" ]]

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -193,6 +193,22 @@ test_valid_identifiers()
     wd -q add ":foo"
     assertFalse "should not allow colons" \
         "$pipestatus"
+
+    wd -q add "foo:"
+    assertFalse "should not allow colons" \
+        "$pipestatus"
+
+    wd -q add "foo/bar"
+    assertFalse "should not allow slashes" \
+        "$pipestatus"
+
+    wd -q add "foo/"
+    assertFalse "should not allow slashes" \
+        "$pipestatus"
+
+    wd -q add "/foo"
+    assertFalse "should not allow slashes" \
+        "$pipestatus"
 }
 
 test_removal()

--- a/wd.sh
+++ b/wd.sh
@@ -175,9 +175,9 @@ wd_add()
     elif [[ $point =~ "[[:space:]]+" ]]
     then
         wd_exit_fail "Warp point should not contain whitespace"
-    elif [[ $point == *:* ]]
+    elif [[ $point =~ : ]] || [[ $point =~ / ]]
     then
-        wd_exit_fail "Warp point cannot contain colons"
+        wd_exit_fail "Warp point contains illegal character (:/)"
     elif [[ ${points[$point]} == "" ]] || [ ! -z "$force" ]
     then
         wd_remove "$point" > /dev/null

--- a/wd.sh
+++ b/wd.sh
@@ -270,7 +270,7 @@ wd_ls()
 wd_path()
 {
     wd_getdir "$1"
-    echo "$(echo "$dir" | sed "s:${HOME}:~:g")"
+    echo "$(echo "$dir" | sed "s:~:${HOME}:g")"
 }
 
 wd_show()


### PR DESCRIPTION
Will close #59 

While a semi-destructive solution to the problem, as it removes functionality to the user, allowing slashes in warp names would prevent a feature like #66 being implemented, which I think has more value than a niche of people wanting slashes in warp point names.

However, because this isn't an 'everyone wins' situation, I'm making a PR and asking for input, from ideally the issue opener @joncalhoun and another maintainer

Tests have been added for this new prevention