### PR TITLE
disallow warp point names that clash with commands

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -209,6 +209,38 @@ test_valid_identifiers()
     wd -q add "/foo"
     assertFalse "should not allow slashes" \
         "$pipestatus"
+
+    wd -q add "add"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "rm"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "show"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "list"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "ls"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "path"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "clean"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
+
+    wd -q add "help"
+    assertFalse "should not allow command names" \
+        "$pipestatus"
 }
 
 test_removal()

--- a/wd.sh
+++ b/wd.sh
@@ -163,6 +163,7 @@ wd_add()
 {
     local point=$1
     local force=$2
+    cmdnames=(add rm show list ls path clean)
 
     if [[ $point == "" ]]
     then
@@ -178,6 +179,9 @@ wd_add()
     elif [[ $point =~ : ]] || [[ $point =~ / ]]
     then
         wd_exit_fail "Warp point contains illegal character (:/)"
+    elif (($cmdnames[(Ie)$point]))
+    then
+        wd_exit_fail "Warp point name cannot be a wd command (see wd -h for a full list)"
     elif [[ ${points[$point]} == "" ]] || [ ! -z "$force" ]
     then
         wd_remove "$point" > /dev/null

--- a/wd.sh
+++ b/wd.sh
@@ -163,7 +163,7 @@ wd_add()
 {
     local point=$1
     local force=$2
-    cmdnames=(add rm show list ls path clean)
+    cmdnames=(add rm show list ls path clean help)
 
     if [[ $point == "" ]]
     then


### PR DESCRIPTION
A warp point such as "list" can be set through "wd add list", but then
"wd list" does not chdir to it, but rather invokes the list command. To
prevent confusion, such warp points names should not be allowed.