### PR TITLE
Support alternate GNU getopt binary on OpenBSD

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -406,7 +406,8 @@ do
 done < "$WD_CONFIG"
 
 # get opts
-args=$(getopt -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
+GETOPT=$(command -v gnugetopt 2> /dev/null || command -v getopt || echo getopt)
+args=$($GETOPT -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
 
 # check if no arguments were given, and that version is not set
 if [[ ($? -ne 0 || $#* -eq 0) && -z $wd_print_version ]]


### PR DESCRIPTION
OpenBSD `getopt` does not support `-l`.  There's a `gnugetopt` port/package that is the GNU implementation (the one on Linux) that supports `-l`.  So if `gnugetopt` is present in the PATH use that, otherwise use `getopt`.

This is coming from https://github.com/ohmyzsh/ohmyzsh/pull/9677.