### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ In your `.zshrc`:
 antibody bundle mfaerevaag/wd
 ```
 
+### Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `wd` in just one click.
+
+<a href="https://fig.io/plugins/other/wd_mfaerevaag" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+
 ### Arch ([AUR](https://aur.archlinux.org/packages/zsh-plugin-wd-git/))
 
 1. Install from the AUR

--- a/README.md
+++ b/README.md
@@ -36,14 +36,9 @@ In your `.zshrc`:
 antibody bundle mfaerevaag/wd
 ```
 
-### Fig
+### [Fig](https://fig.io)
 
-[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
-
-Install `wd` in just one click.
-
-<a href="https://fig.io/plugins/other/wd_mfaerevaag" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
-
+Install `wd` here: [![Fig plugin store](https://fig.io/badges/install-with-fig.svg)](https://fig.io/plugins/other/wd_mfaerevaag)
 
 ### Arch ([AUR](https://aur.archlinux.org/packages/zsh-plugin-wd-git/))
 


### PR DESCRIPTION
We recently listed wd on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. We have over 100k users that will benefit from this. 

Thanks so much and please let me know if you have any questions!

