### PR TITLE
Fix "wd list" error if path contains symbol ":"

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -255,7 +255,7 @@ wd_list_all()
         then
             arr=(${(s,:,)line})
             key=${arr[1]}
-            val=${arr[2]}
+            val=${line#"${arr[1]}:"}
 
             if [[ -z $wd_quiet_mode ]]
             then


### PR DESCRIPTION
Fix the warp points not complete issue:

## create warp point

```zsh
~/demo:cpp % wd add democpp
 * Warp point added
```

## original

```zsh
~/demo:cpp % wd list
 * All warp points:
democpp  ->  ~/demo
```

## after this fix

```zsh
~/demo:cpp % wd list
 * All warp points:
democpp  ->  ~/demo:cpp
```