### PR TITLE
Disable extglob completely

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -280,8 +280,6 @@ wd_path()
 wd_show()
 {
     local name_arg=$1
-    setopt | grep -q extendedglob
-    local extglob=$?
     # if there's an argument we look up the value
     if [[ -n $name_arg ]]
     then
@@ -292,7 +290,6 @@ wd_show()
             wd_print_msg "$WD_GREEN" "Warp point: ${WD_GREEN}$name_arg${WD_NOC} -> $points[$name_arg]"
         fi
     else
-        [[ $extglob ]] && setopt noextendedglob
         # hax to create a local empty array
         local wd_matches
         wd_matches=()
@@ -312,7 +309,6 @@ wd_show()
         else
             wd_print_msg "$WD_YELLOW" "No warp point to $(echo "$PWD" | sed "s:$HOME:~:")"
         fi
-        [[ $extglob ]] && setopt extendedglob
     fi
 }
 
@@ -396,6 +392,11 @@ then
 else
     wd_export_static_named_directories
 fi
+
+# disable extendedglob for the complete wd execution time
+setopt | grep -q extendedglob
+extglobIsSet=$?
+[[ $extglobIsSet ]] && setopt noextendedglob
 
 # load warp points
 typeset -A points
@@ -482,6 +483,8 @@ fi
 ## garbage collection
 # if not, next time warp will pick up variables from this run
 # remember, there's no sub shell
+
+[[ $extglobIsSet ]] && setopt extendedglob
 
 unset wd_warp
 unset wd_add

--- a/wd.sh
+++ b/wd.sh
@@ -395,8 +395,8 @@ fi
 
 # disable extendedglob for the complete wd execution time
 setopt | grep -q extendedglob
-extglobIsSet=$?
-[[ $extglobIsSet ]] && setopt noextendedglob
+wd_extglob_is_set=$?
+[[ $wd_extglob_is_set ]] && setopt noextendedglob
 
 # load warp points
 typeset -A points
@@ -484,8 +484,9 @@ fi
 # if not, next time warp will pick up variables from this run
 # remember, there's no sub shell
 
-[[ $extglobIsSet ]] && setopt extendedglob
+[[ $wd_extglob_is_set ]] && setopt extendedglob
 
+unset wd_extglob_is_set
 unset wd_warp
 unset wd_add
 unset wd_remove


### PR DESCRIPTION
while wd is running, that is.

I have additional problems with variable expansion related to ~, e.g. in prompts and terminal titles. I propose this change, because ~ globbing is done in other places as well. Tests pass.