### PR TITLE
Add test for ~-containing targets

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -322,6 +322,14 @@ test_show()
     then
         fail "should not show warp point 'qux'"
     fi
+
+    # test target in $HOME is listed/shown
+    cd ${HOME}
+    wd -q add home
+    if [[ ! $(wd show) =~ '1 warp point.*:.*home' ]]
+    then
+        fail "should show warp pont 'home'"
+    fi
 }
 
 test_quiet()

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -328,7 +328,7 @@ test_show()
     wd -q add home
     if [[ ! $(wd show) =~ '1 warp point.*:.*home' ]]
     then
-        fail "should show warp pont 'home'"
+        fail "should show warp point 'home'"
     fi
 }
 


### PR DESCRIPTION
While we cannot test the wrong behaviour (~-target not shown) in a meaningful way, we certainly can test for the correct one.