### PR TITLE
fix: extend compatibility to zsh <5.0.6

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -396,7 +396,7 @@ fi
 # disable extendedglob for the complete wd execution time
 setopt | grep -q extendedglob
 wd_extglob_is_set=$?
-[[ $wd_extglob_is_set ]] && setopt noextendedglob
+(( ! $wd_extglob_is_set )) && setopt noextendedglob
 
 # load warp points
 typeset -A points
@@ -484,7 +484,7 @@ fi
 # if not, next time warp will pick up variables from this run
 # remember, there's no sub shell
 
-[[ $wd_extglob_is_set ]] && setopt extendedglob
+(( ! $wd_extglob_is_set )) && setopt extendedglob
 
 unset wd_extglob_is_set
 unset wd_warp


### PR DESCRIPTION
Hi!
I am the maintainer of Oh My Zsh, and we bumped into [this issue](https://github.com/ohmyzsh/ohmyzsh/issues/12017) that I could reproduce. It seems that the syntax `[[ 1 ]]` (or any number actually) is invalid in zsh <5.0.6.
[We already fixed it](https://github.com/ohmyzsh/ohmyzsh/pull/12019), here you have the changes.
Thanks for your work!