### PR TITLE
Include instructions for installing with home manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ wd() {
 }
 ```
 
+### [Home Manager](https://github.com/nix-community/home-manager)
+
+Add the following to your `home.nix` then run `home-manager switch`:
+
+```nix
+programs.zsh.plugins = [
+  {
+    name = "wd";
+    src = pkgs.fetchFromGitHub {
+      owner = "mfaerevaag";
+      repo = "wd";
+      rev = "v0.5.2";
+      sha256 = "sha256-4yJ1qhqhNULbQmt6Z9G22gURfDLe30uV1ascbzqgdhg=";
+    };
+  }
+];
+```
+
 ### [zplug](https://github.com/zplug/zplug)
 
 ```zsh


### PR DESCRIPTION
### Summary

This PR adds a section to the installation instructions for installing the current version of `wd` with [home manager](https://github.com/nix-community/home-manager). Tested this with [my own setup](https://github.com/zimeg/.DOTFILES/blob/e80adb44650d0dde4314e1c14e6f4909ea7a4fa6/nix/home.nix#L33-L43) and it seems to be working well!

### Notes

The `rev` and `sha256` fields are tied to a specific release tag and might need updating with new releases. Or it could just be reference for the format. Using the latest tag with an incorrect hash will error with the correct hash displayed, so it's not too bad to figure out the new hash.

<details>

<summary>
But a more formal approach might use `nix-prefetch` to find the actual hash for the version.
</summary>

```sh
$ nix-prefetch-git https://github.com/mfaerevaag/wd v0.5.2
...
{
  "url": "https://github.com/mfaerevaag/wd",
  "rev": "a3ee1ec68ef172d7f8e8f48266ea680c801217b9",
  "date": "2022-10-06T18:18:47+01:00",
  "path": "/nix/store/hjda1gwzxiz3i1axcnwwj71swkvj9kfw-wd",
  "sha256": "063nl0x6y75bsnalppyy69y121fsnv8nfykb8bdl4dd13am7a8p3",
  "hash": "sha256-4yJ1qhqhNULbQmt6Z9G22gURfDLe30uV1ascbzqgdhg=",
  "fetchLFS": false,
  "fetchSubmodules": false,
  "deepClone": false,
  "leaveDotGit": false
}
```

</details>

If this section is wanted in the `README.md` I'm happy to also add documentation for bumping these values elsewhere!

### Reference

- [Documentation for the home manager `zsh` options is listed here](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.zsh.plugins)
- [The repository for `nix-prefetch` can be found here](https://github.com/msteen/nix-prefetch/)