### PR TITLE
ci(release): bump versions to the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      VERSION: ${{ inputs.version }}
     steps:
       - name: checkout code
         uses: actions/checkout@v4
@@ -22,6 +20,11 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - name: parse input
+        run: |
+          VERSION=$(echo "${{ inputs.version }}" | sed -E "s/^v//g")
+          echo $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: bump versions
         run: |
           DATE=$(date +"%B %d %Y")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        default: "0.0.1"
         description: "Version of the release"
         required: true
         type: string

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,9 @@ jobs:
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: parse input
         run: |
-          VERSION=$(echo "${{ inputs.version }}" | sed -E "s/^v//g")
-          echo $VERSION
+          VERSION=$(echo "${{ inputs.version }}" | sed -E "s/^v//g") # Ex: 1.2.3
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-          DATE=$(date +"%Y-%m-%d")
+          DATE=$(date +"%Y-%m-%d") # Ex: 2022-02-22
           echo "DATE=$DATE" >> $GITHUB_ENV
       - name: bump versions
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,10 @@ jobs:
           VERSION=$(echo "${{ inputs.version }}" | sed -E "s/^v//g")
           echo $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          DATE=$(date +"%Y-%m-%d")
+          echo "DATE=$DATE" >> $GITHUB_ENV
       - name: bump versions
         run: |
-          DATE=$(date +"%B %d %Y")
           MANPAGE=".TH wd \"1\" \"$DATE\" \"wd $VERSION\" \"wd Manual\""
           sed -i -E "1 s/.*/$MANPAGE/" wd.1
           sed -i -E "s/WD_VERSION=.*/WD_VERSION=$VERSION/" wd.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
         run: |
           gh release create "v$VERSION" --generate-notes
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: configure git
         run: |
           git config --global user.name 'github-actions[bot]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           git add wd.1 wd.sh
           git commit -m "chore(update): bump current version to v$VERSION"
-          git tag v$VERSION
+          git tag "v$VERSION"
           git push -u origin master --tags
       - name: release latest
         run: |
-          gh release create v$VERSION --generate-notes
+          gh release create "v$VERSION" --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        default: "0.0.1"
+        description: "Version of the release"
+        required: true
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: configure git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+      - name: bump versions
+        run: |
+          DATE=$(date +"%B %d %Y")
+          MANPAGE=".TH wd \"1\" \"$DATE\" \"wd $VERSION\" \"wd Manual\""
+          sed -i -E "1 s/.*/$MANPAGE/" wd.1
+          sed -i -E "s/WD_VERSION=.*/WD_VERSION=$VERSION/" wd.sh
+      - name: commit changes
+        run: |
+          git add wd.1 wd.sh
+          git commit -m "chore(update): bump current version to v$VERSION"
+          git tag v$VERSION
+          git push -u origin master --tags
+      - name: release latest
+        run: |
+          gh release create v$VERSION --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Summary

👋 Howdy! This PR bumps version numbers and updates a date before creating a new release via GitHub Action. Motivation: https://github.com/mfaerevaag/wd/commit/c7a72236718712fc8fde2fb7cdb4891197de1967#comments

### Preview

Some testing was done on [this fork](https://github.com/zimeg/wd). Interesting commits and other things to note might include:

- 760d84e60daf533dc7634427f964ab252f3c79d5: This exact commit. No differences from this PR except that it's merged to `master`.
- ec4cde58da16910f90fdd32d09705d664561173d: An example PR. Changes must be made through PR to be included in release notes automatically. Edits to these notes after are of course possible. New contributors will be included too!
- 72388003378f6c285027adcdb78ce0733f4fb315: Automated changes. The `--version` variable is updated, and the date and version values of `man wd` are also updated.
- https://github.com/zimeg/wd/actions/runs/9538098867/job/26286893438: The latest example run.
- https://github.com/zimeg/wd/releases/tag/v1.2.9: The automated release notes.

### Runbook

To create one of these releases, the version of the release can be entered for [this action](https://github.com/mfaerevaag/wd/actions/workflows/release.yml) and the rest happens in workflow.

<img width="756" alt="release" src="https://github.com/mfaerevaag/wd/assets/18134219/ca73ab78-2864-49fb-8581-9feecb7456d7">

### Notes

- Reference for `man` pages: https://www.man7.org/linux/man-pages/man7/man-pages.7.html
- The versions used in testing are nonsense. I just started at `1.2.3` and incremented until things worked 😋