### PR TITLE
Document C^B mapping in error message.

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -255,7 +255,10 @@ wd_remove()
 
 wd_browse() {
     if ! command -v fzf >/dev/null; then
-        echo "This functionality requires fzf. Please install fzf first."
+        echo "This functionality of wd requires fzf. Please install fzf" \
+             "first or disable the use of fzf setting" \
+             "`bindkey ${FZF_WD_BINDKEY:-'^B'} backward-char` in your" \
+             ".zshrc after the wd plugin is loaded."
         return 1
     fi
     local entries=("${(@f)$(sed "s:${HOME}:~:g" "$WD_CONFIG" | awk -F ':' '{print $1 " -> " $2}')}")


### PR DESCRIPTION
Thanks for the amazing plugin and apologies for anything I've done wrong with this contribution.

I recently updated OMZSH and run into the issue that fzf wasn't installed. The real challenge was having no clue what plugin changed. My goal with this change is to make the error message clearer by specifying the name of the plugin and also by describing how to override the config.