### PR TITLE
Remove omz plugin bindkey for browse

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ rm -f ~/.zcompdump; compinit
 
 ## Browse
 
-If you want to make use of the `fzf`-powered browse feature to fuzzy search through all your warp points, set up a keybind in your `.zshrc`:
+`wd` comes with an `fzf`-powered browse feature to fuzzy search through all your warp points. It's available through the `wd browse` command. For quick access you can set up an alias or keybind in your `.zshrc`:
 
 ```zsh
-bindkey ${FZF_WD_BINDKEY:-'^B'} fuzzy_wd_widget
+# ctrl-b to open the fzf browser
+bindkey ${FZF_WD_BINDKEY:-'^B'} wd_browse_widget
 ```
 
 ## Usage

--- a/wd.plugin.zsh
+++ b/wd.plugin.zsh
@@ -18,4 +18,3 @@ zle -N wd_browse_widget
 zle -N wd_restore_buffer
 autoload -Uz add-zle-hook-widget
 add-zle-hook-widget line-init wd_restore_buffer
-bindkey ${FZF_WD_BINDKEY:-'^B'} wd_browse_widget


### PR DESCRIPTION
The ctrl-b key is used for fundamental navigation in default emacs-style zsh, and it isn't clear that wd is rebinding it.

Instead of guessing at what keybind would be suited, it's just removed and the docs are made clearer.

See #133 