### PR TITLE
fix: find the path to zsh with the env program

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 
 # WARP
 # ====

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -1,4 +1,4 @@
-#! /bin/zsh
+#!/usr/bin/env zsh
 
 # The tests avoid using wd's internal functions to check the state of
 # warp points. We use `--quiet` to prevent the test output being

--- a/wd.plugin.zsh
+++ b/wd.plugin.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # WARP DIRECTORY
 # ==============

--- a/wd.sh
+++ b/wd.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # WARP DIRECTORY
 # ==============


### PR DESCRIPTION
### Summary

This PR gathers the interpreted `zsh` path using the `env` program to fix #135 and allow changed paths to the `zsh` program.

The `test/tests.sh` file was also updated to run these tests, but the files in `test/shunit2/*` are left as-is which seems to work fine! Tests pass with this change 🎉  

### Reviewers

Test these updates with a package manager of choice and these commands:

```zsh
$ wd
...
$ wd --version
wd version 0.8.0
```

Also check that warps and other commands continue to warp:

```zsh
$ wd list
...
$ cd
$ pwd
$ wd [example]  # Perform a warp
$ pwd
```

### Notes

This seems to work on the following setups, but I'm uncertain about other platforms - all other testing would be super appreciated:

- zsh 5.9 (aarch64-apple-darwin23.6.0)
- zsh 5.9 (x86_64-pc-linux-gnu)

Also open to rebasing commits if needed, just separated changes that changed different files 😉 