### PR TITLE
fix: return erroring exit codes with the set exit value

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,12 +256,6 @@ wd --version
 wd --config ./file <command>
 ```
 
-* Force `exit` with return code after running. This is not default, as it will *exit your terminal*, though required for testing/debugging.
-
-```zsh
-wd --debug <command>
-```
-
 * Silence all output:
 
 ```zsh

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -40,8 +40,7 @@ WD_PATH=${PWD}/..
 
 wd()
 {
-    # run the local wd in debug mode
-    "${WD_PATH}"/wd.sh -d "$@"
+    "${WD_PATH}"/wd.sh "$@"
 }
 
 # MacOS's `wc` command adds extra padding to the front of the command.

--- a/wd.1
+++ b/wd.1
@@ -53,9 +53,6 @@ Print the running version.
 .IP "-c, --config"
 Specifically set the config file (default `~/.warprc`), which is useful when testing.
 .
-.IP "-d, --debug"
-Force `exit` with return code after running. This is not default, as it will *exit your terminal*, though required when testing/debugging.
-.
 .IP "-q, --quiet"
 Silence all output.
 .

--- a/wd.sh
+++ b/wd.sh
@@ -90,7 +90,6 @@ Commands:
     clean                Remove points warping to nonexistent directories (will prompt unless --force is used)
 
     -v | --version  Print version
-    -d | --debug    Exit after execution with exit codes (for testing)
     -c | --config   Specify config file (default ~/.warprc)
     -q | --quiet    Suppress all output
     -f | --force    Allows overwriting without warning (for add & clean)
@@ -426,7 +425,6 @@ wd_export_static_named_directories() {
 WD_CONFIG=${WD_CONFIG:-$HOME/.warprc}
 local WD_QUIET=0
 local WD_EXIT_CODE=0
-local WD_DEBUG=0
 
 # Parse 'meta' options first to avoid the need to have them before
 # other commands. The `-D` flag consumes recognized options so that
@@ -436,7 +434,6 @@ zparseopts -D -E \
     c:=wd_alt_config -config:=wd_alt_config \
     q=wd_quiet_mode -quiet=wd_quiet_mode \
     v=wd_print_version -version=wd_print_version \
-    d=wd_debug_mode -debug=wd_debug_mode \
     f=wd_force_mode -force=wd_force_mode
 
 if [[ ! -z $wd_print_version ]]
@@ -582,10 +579,5 @@ unset wd_o
 unset args
 unset points
 unset val &> /dev/null # fixes issue #1
-
-if [[ -n $wd_debug_mode ]]
-then
-    unset wd_debug_mode
-fi
 
 return $WD_EXIT_CODE

--- a/wd.sh
+++ b/wd.sh
@@ -585,7 +585,7 @@ unset val &> /dev/null # fixes issue #1
 
 if [[ -n $wd_debug_mode ]]
 then
-    exit $WD_EXIT_CODE
-else
     unset wd_debug_mode
 fi
+
+return $WD_EXIT_CODE


### PR DESCRIPTION
### Summary

This PR returns the `$WD_EXIT_CODE` to whatever it might be set to when this program completes for all cases, not just the testing done in debug mode, to fix #137.

### Preview

With the changes of this branch, the following commands continue to **warp** or exit with the error code:

```zsh
$ wd list
...
$ cd
$ wd [example]
$ echo $?
0
$ pwd
$ wd bogus
 * Unknown warp point 'bogus'
$ echo $?
1
```

### Notes

A `return` is preferred to `exit` to avoid quitting the sourced shell session, but I'm not certain about this change so thoughts or more testing for this would be nice!

I've tested both errors and successful warps on the following setups, and feel mostly confident with these:

- zsh 5.9 (aarch64-apple-darwin23.6.0)
- zsh 5.9 (x86_64-pc-linux-gnu)

The unit testing asserts also seem to have been working as expected since `$wd_debug_mode` is set to `true` in tests and this continues to remain the case! An update was also made to unset a set debug mode variable here too, while keeping the same tested exit behavior.