### PR TITLE
don't clobber PWD in wd_show

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -59,7 +59,7 @@ wd_print_msg()
     then
         local color="${1:-$WD_BLUE}"  # Default to blue if no color is provided
         local msg="$2"
-        
+
         if [[ -z "$msg" ]]; then
             print "${WD_RED}*${WD_NOC} Could not print message. Sorry!"
         else
@@ -344,6 +344,7 @@ wd_path()
 wd_show()
 {
     local name_arg=$1
+    local SHOW_PWD
     # if there's an argument we look up the value
     if [[ -n $name_arg ]]
     then
@@ -358,12 +359,12 @@ wd_show()
         local wd_matches
         wd_matches=()
         # do a reverse lookup to check whether PWD is in $points
-        PWD="${PWD/$HOME/~}"
-        if [[ ${points[(r)$PWD]} == "$PWD" ]]
+        SHOW_PWD="${PWD/$HOME/~}"
+        if [[ ${points[(r)$SHOW_PWD]} == "$SHOW_PWD" ]]
         then
             for name in ${(k)points}
             do
-                if [[ $points[$name] == "$PWD" ]]
+                if [[ $points[$name] == "$SHOW_PWD" ]]
                 then
                     wd_matches[$(($#wd_matches+1))]=$name
                 fi

--- a/wd.sh
+++ b/wd.sh
@@ -372,7 +372,7 @@ wd_show()
 
             wd_print_msg "$WD_BLUE" "$#wd_matches warp point(s) to current directory: ${WD_GREEN}$wd_matches${WD_NOC}"
         else
-            wd_print_msg "$WD_YELLOW" "No warp point to $(echo "$PWD" | sed "s:$HOME:~:")"
+            wd_print_msg "$WD_YELLOW" "No warp point to $show_pwd"
         fi
     fi
 }

--- a/wd.sh
+++ b/wd.sh
@@ -344,7 +344,7 @@ wd_path()
 wd_show()
 {
     local name_arg=$1
-    local SHOW_PWD
+    local show_pwd
     # if there's an argument we look up the value
     if [[ -n $name_arg ]]
     then
@@ -359,12 +359,12 @@ wd_show()
         local wd_matches
         wd_matches=()
         # do a reverse lookup to check whether PWD is in $points
-        SHOW_PWD="${PWD/$HOME/~}"
-        if [[ ${points[(r)$SHOW_PWD]} == "$SHOW_PWD" ]]
+        show_pwd="${PWD/$HOME/~}"
+        if [[ ${points[(r)$show_pwd]} == "$show_pwd" ]]
         then
             for name in ${(k)points}
             do
-                if [[ $points[$name] == "$SHOW_PWD" ]]
+                if [[ $points[$name] == "$show_pwd" ]]
                 then
                     wd_matches[$(($#wd_matches+1))]=$name
                 fi


### PR DESCRIPTION
Resolves #114 

use a local variable within `wd_show` to check if we are in a warp point directory or not

```
❯ wd list
 * All warp points:
control-deploy  ->  ~/git/ose-automation-puppet/control-deploy
          dope  ->  ~/git/one-thd/dope
       ls-base  ->  ~/git/one-thd/locksmith

V6YNJVV4QCMBP in ~/git
❯ wd dope

V6YNJVV4QCMBP in git/one-thd/dope
❯ wd show
 * 1 warp point(s) to current directory: dope

V6YNJVV4QCMBP in git/one-thd/dope
❯ cd ..

V6YNJVV4QCMBP in ~/git/one-thd
❯ wd show
 * No warp point to ~/git/one-thd

V6YNJVV4QCMBP in ~/git/one-thd
❯ echo $PWD
/Users/jxb2016/git/one-thd
```