### PR TITLE
fix: set the exit code to the return of cd for the warp function

### DIFF
--- a/test/tests.sh
+++ b/test/tests.sh
@@ -89,6 +89,39 @@ test_empty_config()
         0 "$(total_wps)"
 }
 
+test_wd_point()
+{
+    cwd="$PWD"
+    wd -q add cwd
+    assertTrue "should add the working directory as a custom warp point" \
+        "$pipestatus"
+    command rm -rf "$WD_TEST_DIR"
+    command mkdir "$WD_TEST_DIR"
+    cd "$WD_TEST_DIR"
+    wd -q add
+    assertTrue "should add another directory using a default warp point" \
+        "$pipestatus"
+    command mkdir "$WD_TEST_DIR_2"
+    cd ..
+    wd "$WD_TEST_DIR"
+    assertTrue "should successfully warp to a default point" \
+        "$pipestatus"
+    assertEquals "should be in the default warped directory" \
+        "$cwd/$WD_TEST_DIR" "$(pwd)"
+    wd cwd
+    assertEquals "should successfully return to cwd with a warp point" \
+        "$cwd" "$(pwd)"
+    wd "$WD_TEST_DIR" "$WD_TEST_DIR_2"
+    assertTrue "should successfully warp to nested directory of point" \
+        "$pipestatus"
+    assertEquals "should be in the nested directory of the warp point" \
+        "$cwd/$WD_TEST_DIR/$WD_TEST_DIR_2" "$(pwd)"
+    wd -q moon
+    assertFalse "should fail to warp to a point that does not exist" \
+        "$pipestatus"
+    command rm -rf "$WD_TEST_DIR"
+}
+
 test_simple_add_remove()
 {
     wd -q add foo

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -119,6 +119,9 @@ test_wd_point()
     wd -q moon
     assertFalse "should fail to warp to a point that does not exist" \
         "$pipestatus"
+    wd -q "$WD_TEST_DIR" pluto 2&> /dev/null
+    assertFalse "should fail warping to nonexistent nested directories" \
+        "$pipestatus"
     command rm -rf "$WD_TEST_DIR"
 }
 

--- a/wd.sh
+++ b/wd.sh
@@ -145,14 +145,17 @@ wd_warp()
         else
             (( n = $#1 - 1 ))
             cd -$n > /dev/null
+            WD_EXIT_CODE=$?
         fi
     elif [[ ${points[$point]} != "" ]]
     then
         if [[ $sub != "" ]]
         then
             cd ${points[$point]/#\~/$HOME}/$sub
+            WD_EXIT_CODE=$?
         else
             cd ${points[$point]/#\~/$HOME}
+            WD_EXIT_CODE=$?
         fi
     else
         wd_exit_fail "Unknown warp point '${point}'"


### PR DESCRIPTION
### Summary

:wave: 🤠 This PR updates the exit code with the returned value from `cd` in the `wd_warp` function to fix #142 and break chained commands if nested directories don't exist.

### Preview

With this change the exit code is set to `1` when a missing nested warp point is provided:

```zsh
$ wd home unknown
wd_warp:cd:19: no such file or directory: /home/user/unknown
$ echo $?
1
```

Chained commands also break once the missing nested warp point is reached:

```zsh
$ wd home unknown && ./setup.sh
wd_warp:cd:19: no such file or directory: /home/user/unknown
```

### Reviewers

To test the changes with this branch checked out, the following commands might be useful ✨ 

1. Attempt to warp to unknown nested warp points:

```zsh
$ cd
$ wd add home
$ wd home unknown
wd_warp:cd:19: no such file or directory: /home/user/unknown
$ echo $?
1
$ pwd
/home/user
```

### Notes


This change includes extra commits from #140 for some of the changes to testing. Please let me know if a rebase or other reverts are needed, or another change!