### PR TITLE
Implement `open` command

### DIFF
--- a/_wd.sh
+++ b/_wd.sh
@@ -37,6 +37,7 @@ function _wd() {
     'rm:Removes the given warp point'
     'list:Outputs all stored warp points'
     'ls:Show files from given warp point'
+    'open:Open warp point in the default file explorer'
     'path:Show path to given warp point'
     'show:Outputs all warp points that point to the current directory or shows a specific target directory for a point'
     'help:Show this extremely helpful text'
@@ -71,6 +72,9 @@ function _wd() {
           _describe -t points "Warp points" warp_points && ret=0
           ;;
         ls)
+          _describe -t points "Warp points" warp_points && ret=0
+          ;;
+        open)
           _describe -t points "Warp points" warp_points && ret=0
           ;;
         path)

--- a/wd.1
+++ b/wd.1
@@ -35,6 +35,12 @@ Remove any warp point with \fIname\fP as identifier.
 .IP "ls, -l"
 List all registered warp points.
 .
+.IP "path, -p, --path <name>"
+Show the path to given warp point (pwd)
+.
+.IP "open, -o, --open <name>"
+Open the warp point with the default file explorer. (open / xdg-open)
+.
 .IP "show"
 Show which warp points are registered to the current working directory.
 .

--- a/wd.1
+++ b/wd.1
@@ -38,8 +38,8 @@ List all registered warp points.
 .IP "path, -p, --path <name>"
 Show the path to given warp point (pwd)
 .
-.IP "open, -o, --open <name>"
-Open the warp point with the default file explorer. (open / xdg-open)
+.IP "open <name>, -o <name>, --open <name>"
+Open the \fIname\fP warp point with the default file explorer. (open / xdg-open)
 .
 .IP "show"
 Show which warp points are registered to the current working directory.

--- a/wd.sh
+++ b/wd.sh
@@ -86,6 +86,7 @@ Commands:
     show                 Print warp points to current directory
     list                 Print all stored warp points
     ls  <point>          Show files from given warp point (ls)
+    open <point>         Open the warp point in the default file explorer (open / xdg-open)
     path <point>         Show the path to given warp point (pwd)
     clean                Remove points warping to nonexistent directories (will prompt unless --force is used)
 
@@ -377,6 +378,21 @@ wd_ls()
     ls "${dir/#\~/$HOME}"
 }
 
+wd_open()
+{
+    wd_getdir "$1"
+    if command -v open >/dev/null 2>&1; then
+        # MacOS, Ubuntu (alias)
+        open "${dir/#\~/$HOME}"
+    elif command -v xdg-open >/dev/null 2>&1; then
+        # Most Linux desktops
+        xdg-open "${dir/#\~/$HOME}"
+    else
+        echo "No known file opener found (need 'open' or 'xdg-open')." >&2
+        exit 1
+    fi
+}
+
 wd_path()
 {
     wd_getdir "$1"
@@ -521,7 +537,7 @@ do
 done < "$wd_config_file"
 
 # get opts
-args=$(getopt -o a:r:c:lhs -l add:,rm:,clean,list,ls:,path:,help,show -- $*)
+args=$(getopt -o a:r:c:lhs -l add:,rm:,clean,list,ls:,open:,path:,help,show -- $*)
 
 # check if no arguments were given, and that version is not set
 if [[ ($? -ne 0 || $#* -eq 0) && -z $wd_print_version ]]
@@ -569,6 +585,10 @@ else
                 ;;
             "-ls"|"ls")
                 wd_ls "$2"
+                break
+                ;;
+            "-o"|"--open"|"open")
+                wd_open "$2"
                 break
                 ;;
             "-p"|"--path"|"path")


### PR DESCRIPTION
- Closes #147 

The `open` command is natively available on MacOS. On Linux, `xdg-open` should be widely available, although some distros (Ubuntu?) seem to alias it as `open`. I check for presence of either command, rather than relying on the `$OSTYPE` variable. I hope it's more reliable.

The ZSH autocompletion works fine - tested by copying the new `_wd.sh` file into my oh-my-zsh plugins and running new zsh.

I didn't add any tests, because I don't know how should I test that the desktop environment opened an application.

> [!NOTE]
> I'm on a mac. Someone should test it on linux!