### PR TITLE
docs: recommend latest plugin version with home manager installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,9 @@ Add the following to your `home.nix` then run `home-manager switch`:
 programs.zsh.plugins = [
   {
     name = "wd";
-    src = pkgs.fetchFromGitHub {
-      owner = "mfaerevaag";
-      repo = "wd";
-      rev = "v0.5.2";
-      sha256 = "sha256-4yJ1qhqhNULbQmt6Z9G22gURfDLe30uV1ascbzqgdhg=";
-    };
+    src = pkgs.zsh-wd;
+    file = "share/wd/wd.plugin.zsh";
+    completions = [ "share/zsh/site-functions" ];
   }
 ];
 ```


### PR DESCRIPTION
### Summary

👋 Hello! This PR updates the installation instructions for Home Manager to use the latest `wd` package available.

Follows #117 📚 

### Notes

Original documentation recommended fetching an upstream source because the Home Manager `zsh.plugins` settings weren't finding completions which IMO wouldn't have been good to suggest... 🤖 

A recent update to Home Manager added the `completions` option for plugins which unlocks both autocomplete and manual pages! 👾 

### Reference

- `zsh-wd` on `nixpkgs`: https://search.nixos.org/packages?channel=unstable&query=zsh-wd
- `zsh.plugins`: https://nix-community.github.io/home-manager/options.xhtml#opt-programs.zsh.plugins
- `completions`: https://github.com/nix-community/home-manager/pull/7197