### PR TITLE
fix: exit with error for commands needing missing write access

### DIFF
--- a/wd.sh
+++ b/wd.sh
@@ -174,6 +174,11 @@ wd_add()
         point=$(basename "$PWD")
     fi
 
+    if [ ! -w "$wd_config_file" ]; then
+        wd_exit_fail "\'$wd_config_file\' is not writeable."
+        return
+    fi
+
     if [[ $point =~ "^[\.]+$" ]]
     then
         wd_exit_fail "Warp point cannot be just dots"
@@ -237,6 +242,11 @@ wd_remove()
     if [[ "$point_list" == "" ]]
     then
         point_list=$(basename "$PWD")
+    fi
+
+    if [ ! -w "$wd_config_file" ]; then
+        wd_exit_fail "\'$wd_config_file\' is not writeable."
+        return
     fi
 
     for point_name in $point_list ; do
@@ -440,6 +450,11 @@ wd_clean() {
     local count=0
     local wd_tmp=""
 
+    if [ ! -w "$wd_config_file" ]; then
+        wd_exit_fail "\'$wd_config_file\' is not writeable."
+        return
+    fi
+
     while read -r line
     do
         if [[ $line != "" ]]
@@ -543,14 +558,6 @@ args=$(getopt -o a:r:c:lhs -l add:,rm:,clean,list,ls:,open:,path:,help,show -- $
 if [[ ($? -ne 0 || $#* -eq 0) && -z $wd_print_version ]]
 then
     wd_print_usage
-
-# check if config file is writeable
-elif [ ! -w "$wd_config_file" ]
-then
-    # do nothing
-    # can't run `exit`, as this would exit the executing shell
-    wd_exit_fail "\'$wd_config_file\' is not writeable."
-
 else
     # parse rest of options
     local wd_o


### PR DESCRIPTION
### Summary

👋 Hi! This PR exits with an error for specific commands needing a missing write access to the `.warprc` file instead of all commands.

Fixes an issue where warping finds error on a read only file system ❄️ ✨ 

### Reviewers

I hope all is well. The following commands can confirm this with these changes:

```sh
$ chmod -w ~/.warprc    # Make the configuration read only
$ ./path/to/wd.sh list  # Show known warp points
$ ./path/to/wd.sh add   # Error adding warp points
```

```sh
$ chmod +w ~/.warprc    # Revert file permissions to write
```

### Notes

Commands guarded with **write** include:

- `add`: Writing new points and paths - also captures `addcd`
- `remove`: Deleting existing warp points
- `clean`: Deleing nonexistent paths of points

Commands that do not need **write** are now:

- `<point>`: Warp to the path in settings!
- `browse`: Fuzzy finding in warps
- `export`: Hash known named directories
- `help`: Print a most useful message
- `show`: Print path to a warp point
- `list`: Print all stored warp points
- `ls`: Show files from a given warp
- `open`: Open the warp point in explorer
- `path`: Show the path to a warp point

This change is motivated once more by `nix` and the immutable [store](https://wiki.nixos.org/wiki/Nix_(package_manager)#Nix_store) of package or configuration in this case 🤖